### PR TITLE
Error handling and documentation improvements

### DIFF
--- a/Sources/Lingo/DataSources/LocalizationDataSource.swift
+++ b/Sources/Lingo/DataSources/LocalizationDataSource.swift
@@ -5,8 +5,11 @@ import Foundation
 /// Use it in case your localizations are not stored in JSON files, but rather in a database or other storage technology.
 public protocol LocalizationDataSource {
     
-    func availableLocales() -> [LocaleIdentifier]
+    /// Return a list of available locales.
+    /// Lingo will query for localizations for each of these locales in localizations(for:) method.
+    func availableLocales() throws -> [LocaleIdentifier]
     
-    func localizations(`for` locale: LocaleIdentifier) -> [LocalizationKey: Localization]
+    /// Return localizations for a given locale.
+    func localizations(`for` locale: LocaleIdentifier) throws -> [LocalizationKey: Localization]
     
 }

--- a/Sources/Lingo/Localization.swift
+++ b/Sources/Lingo/Localization.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Object represent localization of a given key in a given language.
+/// Object represents localization of a given key in a given language.
 ///
 /// It has 2 cases:
 /// - `universal` - in case pluralization is not needed and one values is used for all plural categories
@@ -18,7 +18,7 @@ public enum Localization {
             case .pluralized(let values):
                 let pluralCategory = self.pluralCategory(for: locale, interpolations: interpolations)
                 guard let rawString = values[pluralCategory] else {
-                    assertionFailure("Missing plural value for category: \(pluralCategory)")
+                    print("Missing plural value for category: \(pluralCategory). Will default to an empty string.")
                     return ""
                 }
                 
@@ -44,16 +44,19 @@ fileprivate extension Localization {
     /// The PluralCategory is based on the first numeric value in `interpolations` and `PluralizationRule` for the given language.
     /// If no numeric value is found, it fallbacks to `.other`.
     func pluralCategory(`for` locale: LocaleIdentifier, interpolations: [String: Any]?) -> PluralCategory {
-        guard let pluralizationRule = PluralizationRuleStore.pluralizationRule(forLocale: locale) else {
-            assertionFailure("Missing pluralization rule for locale: \(locale). Will default to `other` rule.")
+        // If there are no interpolations, or there is not a single numeric value in them,
+        // there is no way to determine which plural category to use, so default to .other
+        guard let interpolations = interpolations, let numericValue = self.extractNumericValue(from: interpolations) else {
             return .other
         }
         
-        if let interpolations = interpolations, let numericValue = self.extractNumericValue(from: interpolations) {
-            return pluralizationRule.pluralCategory(forNumericValue: numericValue)
+        // If no pluralization rule is defined for current language, default to .other.
+        guard let pluralizationRule = PluralizationRuleStore.pluralizationRule(forLocale: locale) else {
+            print("Missing pluralization rule for locale: \(locale). Will default to `other` rule.")
+            return .other
         }
         
-        return .other
+        return pluralizationRule.pluralCategory(forNumericValue: numericValue)
     }
     
     /// Extract the first numeric value from the interpolations and make it non negative.
@@ -62,7 +65,7 @@ fileprivate extension Localization {
     func extractNumericValue(from interpolations: [String: Any]) -> UInt? {
         for value in interpolations.values {
             if var intValue = value as? Int {
-                // Make sure the value is positive
+                // Make sure the value is always positive
                 if intValue < 0 {
                     intValue *= -1
                 }

--- a/Sources/Lingo/Localization.swift
+++ b/Sources/Lingo/Localization.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Object represents localization of a given key in a given language.
 ///
 /// It has 2 cases:
-/// - `universal` - in case pluralization is not needed and one values is used for all plural categories
+/// - `universal` - in case pluralization is not needed and one value is used for all plural categories
 /// - `pluralized` - in case of different localizations are defined based on a PluralCategory
 public enum Localization {
     

--- a/Sources/Lingo/LocalizationsModel.swift
+++ b/Sources/Lingo/LocalizationsModel.swift
@@ -9,17 +9,7 @@ class LocalizationsModel {
     }
     
     private var data = [LocaleIdentifier: [LocalizationKey: Localization]]()
-    
-    /// Adds localization for a given key and locale. If localization for a given key already exists, it will be overwritten
-    func addLocalization(_ localization: Localization, forKey key: LocalizationKey, locale: LocaleIdentifier) {
-        // Find existing bucket for a given locale or create a new one
-        var localeBucket = self.data[locale] ?? [LocalizationKey: Localization]()
         
-        // Update the data
-        localeBucket[key] = localization
-        self.data[locale] = localeBucket
-    }
-    
     func addLocalizations(_ localizations: [LocalizationKey: Localization], `for` locale: LocaleIdentifier) {
         // Find existing bucket for a given locale or create a new one
         if var existingLocaleBucket = self.data[locale] {

--- a/Tests/LingoTests/LingoTests.swift
+++ b/Tests/LingoTests/LingoTests.swift
@@ -11,22 +11,17 @@ class LingoTests: XCTestCase {
     }
     
     func testNonExistingKeyReturnsRawKeyAsLocalization() throws {
-        let lingo = Lingo(rootPath: self.localizationsRootPath, defaultLocale: nil)
+        let lingo = try Lingo(rootPath: self.localizationsRootPath, defaultLocale: "en")
         XCTAssertEqual(lingo.localize("non.existing.key", locale: "en"), "non.existing.key")
     }
     
-    func testNonExistingLocaleReturnsRawKeyAsLocalizationWhenDefaultLocaleIsNotSpecified() throws {
-        let lingo = Lingo(rootPath: self.localizationsRootPath, defaultLocale: nil)
-        XCTAssertEqual(lingo.localize("hello.world", locale: "non-existing-locale"), "hello.world")
-    }
-    
     func testFallbackToDefaultLocale() throws {
-        let lingo = Lingo(rootPath: self.localizationsRootPath, defaultLocale: "en")
+        let lingo = try Lingo(rootPath: self.localizationsRootPath, defaultLocale: "en")
         XCTAssertEqual(lingo.localize("hello.world", locale: "non-existing-locale"), "Hello World!")
     }
     
     func testLocalization() throws {
-        let lingo = Lingo(rootPath: self.localizationsRootPath, defaultLocale: nil)
+        let lingo = try Lingo(rootPath: self.localizationsRootPath, defaultLocale: "en")
         
         XCTAssertEqual(lingo.localize("hello.world", locale: "en"), "Hello World!")
         XCTAssertEqual(lingo.localize("hello.world", locale: "de"), "Hallo Welt!")


### PR DESCRIPTION
- Replaced all assertions in `FileDataSource` with proper Swift errors, therefor initialization of Lingo now throws.
- Made `defaultLocale` mandatory. I believe that this will simplify the API a bit and just makes more sense to make it required by default.
- Small improvements in plural category extraction in `Localization.swift`.
- Improved documentation.