### PR TITLE
Use key from default if key is not found in locale

### DIFF
--- a/Sources/Lingo/Lingo.swift
+++ b/Sources/Lingo/Lingo.swift
@@ -50,8 +50,12 @@ public final class Lingo {
                 return localizedString
 
             case .missingKey:
-                print("No localizations found for key: \(key), locale: \(locale). Will fallback to raw value of the key.")
-                return key
+                let defaultLocaleResult = self.model.localize(key, locale: self.defaultLocale, interpolations: interpolations)
+                guard case LocalizationsModel.LocalizationResult.success(let localizationInDefaultLocale) = defaultLocaleResult else {
+                    print("No localizations found for key: \(key), locale: \(locale) or in default locale. Will fallback to raw value of the key.")
+                    return key
+                }
+                return localizationInDefaultLocale
             
             case .missingLocale:
                 // Fallback to default locale


### PR DESCRIPTION
Attempt to use the translation from the default locale file if the key is not found in the requested locale, instead of falling back to raw key value.
This is a much more useful behaviour in my opinion.